### PR TITLE
deployment: add resource limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## Overview
 
 This is a HTTP server which accepts GET requests with input parameter as “sortKey” and “limit”. 
-The service queries three URLs mentioned below, combines the results from all three URLs, sorts them by the sortKey and returns the response. 
+The service queries three URLs mentioned below, combines the results from all three URLs, sorts them by the sortKey sortKey (in descending order) and returns the response. 
 - https://raw.githubusercontent.com/assignment132/assignment/main/duckduckgo.json
 - https://raw.githubusercontent.com/assignment132/assignment/main/google.json
 - https://raw.githubusercontent.com/assignment132/assignment/main/wikipedia.json

--- a/deploy/helm/search-results-aggregator/templates/deployment.yaml
+++ b/deploy/helm/search-results-aggregator/templates/deployment.yaml
@@ -41,6 +41,8 @@ spec:
             path: /health
             port: {{ .Values.svc.targetPort }}
           initialDelaySeconds: 5
+        resources:
+          {{- toYaml .Values.resources | nindent 12 }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       imagePullSecrets:

--- a/deploy/helm/search-results-aggregator/values.yaml
+++ b/deploy/helm/search-results-aggregator/values.yaml
@@ -28,3 +28,11 @@ autoscaling:
   maxReplicas: 3
   targetCPUUtilizationPercentage: 80
   targetMemoryUtilizationPercentage: 80
+
+resources:
+  requests:
+    memory: '64Mi'
+    cpu: '100m'
+  limits:
+    memory: '128Mi'
+    cpu: '500m'

--- a/spec/openapi-specs.yaml
+++ b/spec/openapi-specs.yaml
@@ -3,7 +3,8 @@ info:
   title: Search Results Aggregator
   description: |-
     This is a HTTP server which accepts GET requests with input parameter as “sortKey” and “limit”. 
-    The service queries three URLs mentioned below, combines the results from all three URLs, sorts them by the sortKey and returns the response. 
+    The service queries three URLs mentioned below, combines the results from all three URLs, sorts 
+    them by the sortKey (in descending order) and returns the response. 
     - https://raw.githubusercontent.com/assignment132/assignment/main/duckduckgo.json
     - https://raw.githubusercontent.com/assignment132/assignment/main/google.json
     - https://raw.githubusercontent.com/assignment132/assignment/main/wikipedia.json


### PR DESCRIPTION
- add resource limits for deployment manifests
- specify sort order clearly in README and API spec